### PR TITLE
Update make-release workflow to include subject in merge command

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -72,7 +72,7 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - run: gh pr merge --merge --delete-branch
+    - run: gh pr merge --merge --delete-branch --subject "Merge branch release/${{ steps.increment-version.outputs.version }}"
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
- Add `--subject` flag to `gh pr merge` command
- Use the output of `steps.increment-version.outputs.version` as the subject for the merge
