### PR TITLE
Added support for Vanilla Factions Expanded - Mechanoids

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -15,5 +15,6 @@
     <li IfModActive="orion.hospitality">Mods/orion.hospitality</li>
     <li IfModActive="haplo.miscellaneous.robots">Mods/haplo.miscellaneous.robots</li>
     <li IfModActive="alaestor.miscrobots.plusplus">Mods/alaestor.miscrobots.plusplus</li>
+    <li IfModActive="oskarpotocki.vfe.mechanoid">Mods/oskarpotocki.vfe.mechanoid</li>
   </v1.4>
 </loadFolders>

--- a/Mods/oskarpotocki.vfe.mechanoid/Patches/patch.oskarpotocki.vfe.mechanoid.xml
+++ b/Mods/oskarpotocki.vfe.mechanoid/Patches/patch.oskarpotocki.vfe.mechanoid.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Patch>
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>/Defs/ThingDef[defName = "VFE_Mechanoids_Autocleaner"]/race/mechEnabledWorkTypes</xpath>
+    <value>
+      <li>MJobs_PriorityCleaning</li>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>/Defs/ThingDef[defName = "VFE_Mechanoids_Autohauler"]/race/mechEnabledWorkTypes</xpath>
+    <value>
+      <li>MJobs_PriorityHauling</li>
+      <li>MJobs_Delivering</li>
+      <li>MJobs_Loading</li>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>/Defs/ThingDef[defName = "VFE_Mechanoids_Autominer"]/race/mechEnabledWorkTypes</xpath>
+    <value>
+      <li>MJobs_Drilling</li>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>/Defs/ThingDef[defName = "VFE_Mechanoids_AutoMedic"]/race/mechEnabledWorkTypes</xpath>
+    <value>
+      <li>MJobs_Rescuing</li>
+      <li>MJobs_Operating</li>
+      <li>MJobs_Caring</li>
+    </value>
+  </Operation>
+
+</Patch>


### PR DESCRIPTION
The following mechanoids have had their work types adjusted:
- VFE_Mechanoids_Autocleaner
  - added MJobs_PriorityCleaning
- VFE_Mechanoids_Autohauler
  - added MJobs_PriorityHauling, MJobs_Delivering, MJobs_Loading
- VFE_Mechanoids_Autominer
  - added MJobs_Drilling
- VFE_Mechanoids_AutoMedic
  - added MJobs_Rescuing, MJobs_Operating, MJobs_Caring
