### PR TITLE
Update PR label workflow concurrency cancellation

### DIFF
--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -7,7 +7,7 @@ on:
 
 concurrency:
   group: "pr-label-${{ github.ref }}"
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
 


### PR DESCRIPTION
- Set `cancel-in-progress` to false in the PR label workflow concurrency configuration.
