### PR TITLE
Added support for Vanilla Plants Expanded - More Plants

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -28,5 +28,6 @@
     <li IfModActive="vanillaexpanded.vbrewe">Mods/vanillaexpanded.vbrewe</li>
     <li IfModActive="vanillaexpanded.vbrewecandt">Mods/vanillaexpanded.vbrewecandt</li>
     <li IfModActive="oskarpotocki.vfe.insectoid">Mods/oskarpotocki.vfe.insectoid</li>
+    <li IfModActive="vanillaexpanded.vplantsemore">Mods/vanillaexpanded.vplantsemore</li>
   </v1.4>
 </loadFolders>

--- a/Mods/vanillaexpanded.vplantsemore/Patches/patch.vanillaexpanded.vplantsemore.xml
+++ b/Mods/vanillaexpanded.vplantsemore/Patches/patch.vanillaexpanded.vplantsemore.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Patch>
+
+  <Operation Class="XmlExtensions.OptionalPatchExternal">
+    <ModClass>ManyJobs.Mod</ModClass>
+    <field>MJobs_Brewing</field>
+    <caseTrue>
+
+      <Operation Class="XmlExtensions.Conditional">
+        <xpath>Defs/WorkGiverDef[defName = "VCE_DoBillsVegMilkExtractor"]/workType</xpath>
+        <caseTrue>
+          <Operation Class="PatchOperationReplace">
+            <xpath>Defs/WorkGiverDef[defName = "VCE_DoBillsVegMilkExtractor"]/workType</xpath>
+            <value>
+              <workType>MJobs_Brewing</workType>
+            </value>
+          </Operation>
+        </caseTrue>
+      </Operation>
+
+    </caseTrue>
+  </Operation>
+
+</Patch>


### PR DESCRIPTION
If Vanilla Plants Expanded - More Plants is active _and_ Vanilla Cooking Expanded is active, then the "extract milk from plants" job gets reassigned to the brewing category.
