### PR TITLE
Add .editorconfig file with default and C# specific settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+# Top-most EditorConfig file
+
+# Default settings for all files
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+# Override settings for C# files
+[*.cs]
+indent_size = 4
+csharp_style_var_for_built_in_types = false:suggestion
+csharp_style_var_when_type_is_apparent = false:suggestion
+csharp_style_var_elsewhere = false:suggestion


### PR DESCRIPTION
- Added .editorconfig file with default settings for all files
- Set indent style to space and size to 2 spaces
- Set end of line character to lf (line feed)
- Set charset to utf-8
- Enabled trimming trailing whitespace
- Enabled inserting final newline

For C# files:
- Overrode the indent size to 4 spaces
- Disabled suggestions for using 'var' keyword for built-in types, when type is apparent, and elsewhere
